### PR TITLE
Simplify Python doc template with helper filters

### DIFF
--- a/compiler/templates/c++/_structs.hpp
+++ b/compiler/templates/c++/_structs.hpp
@@ -2,6 +2,7 @@
 
 // Forward declarations, including incomplete types
 {% for s in items.abstract_structs -%}
+{%- call m::docs("", s.docs) %}
 struct {{ s.name }};
 {% endfor -%}
 {% for s in items.structs -%}

--- a/compiler/templates/c/_macros.h
+++ b/compiler/templates/c/_macros.h
@@ -1,1 +1,11 @@
 {%- macro comma() %}{% if !loop.last %}, {% endif %}{% endmacro -%}
+
+{%- macro docs(indent, docs) %}
+  {%- if !docs.is_empty() %}
+    {{~ indent }}/*!
+  {%- for doc in docs.iter() %}
+    {{~ indent }} *{{ doc }}
+  {%- endfor %}
+    {{~ indent }} */
+  {%- endif %}
+{%- endmacro %}

--- a/compiler/templates/c/import.h
+++ b/compiler/templates/c/import.h
@@ -23,12 +23,15 @@
 {% import "c/_macros.h" as m %}
 
 {% for s in items.abstract_structs -%}
+{%- call m::docs("", s.docs) %}
 struct {{ s.name }};
 {% endfor %}
 
 {% for s in items.structs %}
+{%- call m::docs("", s.docs) %}
 struct {{ s.name }} {
 {%- for field in s.fields %}
+{%- call m::docs("    ", field.docs) %}
     {{ field.ty|ty }} {{ field.name }};
 {%- endfor %}
 };
@@ -51,6 +54,7 @@ typedef struct { {{ d.slice_name }} slice_data; void (*deleter)({{ d.slice_name 
 {% endfor %}
 
 {% for f in items.functions %}
+{%- call m::docs("", f.docs) %}
 VELLUM_ABI {{ f.returns|retty }} {{ f.name }}(
 {%- for arg in f.args %}
     {{ arg.1|ty }} {{ arg.0 }}{% call m::comma() %}

--- a/compiler/templates/python/module.py
+++ b/compiler/templates/python/module.py
@@ -8,12 +8,31 @@ import vellum
 
 {%- for s in items.abstract_structs %}
 class {{ s.name }}(ct.Structure):
+    __doc__ = "\n".join([
+    {%- for line in s.docs | with_incomplete_note %}
+        {{ line|repr }},
+    {%- endfor %}
+    ])
     pass
 
 {%- endfor %}
 
 {%- for s in items.structs %}
 class {{ s.name }}(ct.Structure):
+    __doc__ = "\n".join([
+    {%- for doc in s.docs %}
+        {{ doc|repr }},
+    {%- endfor %}
+    {%- set field_docs = s.fields | field_docs %}
+    {%- if !field_docs.is_empty() %}
+        {%- if !s.docs.is_empty() %}
+        "",
+        {%- endif %}
+        {%- for line in field_docs %}
+        {{ line|repr }},
+        {%- endfor %}
+    {%- endif %}
+    ])
     _fields_ = [
     {%- for field in s.fields %}
         ('{{ field.name }}', {{ field.ty|ty }}),
@@ -35,3 +54,10 @@ def load(*args):
     {%- endfor %}
 
     return lib
+
+load.__doc__ = "\n".join([
+    'Loads a CDLL with the following functions:',
+{%- for line in items.functions | function_doc_lines %}
+    {{ line|repr }},
+{%- endfor %}
+])


### PR DESCRIPTION
## Summary
- add small Askama filters to append incomplete-type notes, render struct field documentation, and format function doc listings
- update the Python module template to use the new helpers so docstrings stay in the template with less inline control flow

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d0c4e8d4dc8332990eac554ca8c919